### PR TITLE
feat: Implement user progress and favorites

### DIFF
--- a/src/pages/ConteReading.tsx
+++ b/src/pages/ConteReading.tsx
@@ -58,38 +58,6 @@ const defaultImages: { [key: string]: string } = {
   "Aventure": chasseurEspritImg
 };
 
-// Contenu exemple des contes (simule les pages du conte)
-const sampleConteContent = {
-  pages: [
-    {
-      numero: 1,
-      contenu: "Il était une fois, dans un petit village du Mali, une araignée très rusée nommée Anansi. Elle était connue dans tout le village pour son intelligence et sa capacité à résoudre les problèmes les plus difficiles.",
-      image: araigneeElephantImg
-    },
-    {
-      numero: 2,
-      contenu: "Un jour, un énorme éléphant arriva dans le village. Il était si grand et si fort qu'il écrasait tout sur son passage. Les villageois avaient peur et ne savaient plus quoi faire.",
-      image: araigneeElephantImg
-    },
-    {
-      numero: 3,
-      contenu: "Anansi observa l'éléphant pendant quelques jours. Elle remarqua qu'il avait soif et cherchait constamment de l'eau. Elle eut alors une idée géniale pour aider le village.",
-      image: araigneeElephantImg
-    },
-    {
-      numero: 4,
-      contenu: "Anansi tissa une toile géante près du puits du village. Quand l'éléphant vint boire, il se prit les pattes dans la toile. Mais au lieu de se débattre, il se calma.",
-      image: araigneeElephantImg
-    },
-    {
-      numero: 5,
-      contenu: "L'araignée lui expliqua qu'elle pouvait l'aider à trouver un endroit parfait avec beaucoup d'eau, à condition qu'il promette de ne plus détruire le village.",
-      image: araigneeElephantImg
-    }
-  ],
-  morale: "L'intelligence et la ruse peuvent triompher de la force brute. Il ne faut jamais sous-estimer quelqu'un à cause de sa taille ou de son apparence."
-};
-
 const ConteReading = () => {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -106,7 +74,7 @@ const ConteReading = () => {
 
   // États du conte
   const [conte, setConte] = useState<Conte | null>(null);
-  const [pages, setPages] = useState<any[]>(sampleConteContent.pages);
+  const [pages, setPages] = useState<ContePage[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
   const [viewMode, setViewMode] = useState<"page" | "continu">("page");
   const [loading, setLoading] = useState(true);
@@ -163,6 +131,17 @@ const ConteReading = () => {
             navigate('/contes');
             return;
           }
+        }
+
+        // Charger les pages du conte
+        const contePages = await fetchContePages(id);
+        if (contePages.length > 0) {
+          setPages(contePages);
+        } else {
+          // Gérer le cas où il n'y a pas de pages, peut-être rediriger
+          toast.error("Ce conte n'a pas encore de contenu.");
+          navigate('/contes');
+          return;
         }
 
         // Charger le progrès utilisateur
@@ -659,7 +638,7 @@ const ConteReading = () => {
                     </h3>
                   </div>
                   <p className={`${isDarkMode ? 'text-amber-100' : 'text-orange-700'} leading-relaxed`}>
-                    {sampleConteContent.morale}
+                    {conte.morale}
                   </p>
                 </CardContent>
               </Card>

--- a/supabase/migrations/20250812174100_create_user_conte_progress_table.sql
+++ b/supabase/migrations/20250812174100_create_user_conte_progress_table.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS user_conte_progress (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    conte_id UUID NOT NULL REFERENCES contes(id) ON DELETE CASCADE,
+    derniere_page INTEGER NOT NULL DEFAULT 1,
+    termine BOOLEAN NOT NULL DEFAULT FALSE,
+    favori BOOLEAN NOT NULL DEFAULT FALSE,
+    derniere_ecoute TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, conte_id)
+);
+
+-- RLS Policies
+ALTER TABLE user_conte_progress ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow select for authenticated users" ON user_conte_progress
+FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Allow insert for authenticated users" ON user_conte_progress
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Allow update for authenticated users" ON user_conte_progress
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Allow delete for authenticated users" ON user_conte_progress
+FOR DELETE
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Function to update `updated_at` timestamp
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to update `updated_at` on row update
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON user_conte_progress
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();


### PR DESCRIPTION
This commit introduces the following features:
- Adds the ability for users to mark stories as favorites.
- Implements reading progress tracking for stories.
- Fixes a bug on the riddles page that caused an infinite loading state.

A new `user_conte_progress` table has been added to the database to store user-specific data for stories. The `ConteReading` page has been updated to use this table to save and restore user progress and favorite status. The `useDevinettes` hook has been refactored to fix a data fetching issue.