### PR TITLE
fix: Improve subscription check error handling

### DIFF
--- a/src/hooks/useSubscription.tsx
+++ b/src/hooks/useSubscription.tsx
@@ -47,6 +47,12 @@ export const useSubscription = () => {
           description: "Impossible de vérifier l'abonnement",
           variant: "destructive",
         });
+        setSubscriptionData({
+          subscribed: false,
+          subscription_tier: null,
+          subscription_end: null,
+          loading: false,
+        });
         return;
       }
 


### PR DESCRIPTION
This commit makes the frontend more resilient to failures in the `check-subscription` serverless function.

Previously, if the function call failed (e.g., due to a backend misconfiguration or network error), the subscription loading state was not properly reset. This could leave the application in a stuck or inconsistent state, preventing users from accessing content.

The `useSubscription` hook is modified to ensure that in any error case, the subscription state is explicitly set to `loading: false` and `subscribed: false`. This allows the application to gracefully default to a non-subscribed state and ensures that free content remains accessible.